### PR TITLE
Ensure Preston simulator is ready before RPA steps

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -90,7 +90,9 @@ class PrestonRPA:
         """Main automation workflow."""
         logger.info("Starting automation for %d date groups", len(excel_data))
         focus_preston_window(simulator_path)
-        time.sleep(2)
+        if not self._wait_for_main_menu():
+            logger.error("Preston simulator not ready; aborting automation")
+            return
         for entry in excel_data:
             if not self.running:
                 break
@@ -99,6 +101,17 @@ class PrestonRPA:
 
     def stop(self):
         self.running = False
+
+    def _wait_for_main_menu(self, timeout: float = 30) -> bool:
+        """Wait until the main menu is visible on screen."""
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            for variant in UI_TEXTS["finans_izle"]:
+                if self.ocr.find_text_on_screen(variant):
+                    return True
+            time.sleep(1)
+        logger.error("Text '%s' not found on screen", UI_TEXTS["finans_izle"])
+        return False
 
     # The following methods are placeholders demonstrating the sequence.
     def execute_workflow(self, data_entry: Dict[str, object]):


### PR DESCRIPTION
## Summary
- Wait for the Preston simulator's main menu before starting automation
- Abort the workflow if the simulator is not ready

## Testing
- `pytest`
- `python -m py_compile preston_rpa/preston_automation.py`


------
https://chatgpt.com/codex/tasks/task_b_689a68ab8bd4832faff5e92029126e19