### PR TITLE
Improve Preston readiness checks and OCR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openpyxl>=3.1.0
 pyautogui>=0.9.54
 pygetwindow>=0.0.9
 numpy>=1.24.0
+uiautomation>=2.0.0


### PR DESCRIPTION
## Summary
- Strengthen Chrome tab readiness via ROI-based OCR and debug screenshots
- Add normalization and variant support to OCR text search
- Log clear abort message when Preston window is not active

## Testing
- `python -m py_compile preston_rpa/preston_automation.py preston_rpa/ocr_engine.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a6abfeaf4832f8d6f1c2f8761a45b