### PR TITLE
Enhance OCR matching robustness

### DIFF
--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -8,6 +8,8 @@ OCR_CONFIDENCE = 0.8
 OCR_LANGUAGE = "tur"
 # Tesseract configuration string (single line mode for menu bar)
 OCR_TESSERACT_CONFIG = "--psm 7"
+# Minimum similarity ratio (0-1) for fuzzy text matching in OCR
+OCR_FUZZY_THRESHOLD = 0.8
 
 # Timing Settings
 CLICK_DELAY = 1.0


### PR DESCRIPTION
## Summary
- add configurable fuzzy matching threshold for OCR
- use difflib SequenceMatcher to detect approximate text matches

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_689a6c8458d4832f82c13976438f3517