### PR TITLE
Improve OCR navigation with word pair detection

### DIFF
--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -9,7 +9,7 @@ OCR_LANGUAGE = "tur"
 # Tesseract configuration string (single line mode for menu bar)
 OCR_TESSERACT_CONFIG = "--psm 7"
 # Minimum similarity ratio (0-1) for fuzzy text matching in OCR
-OCR_FUZZY_THRESHOLD = 0.8
+OCR_FUZZY_THRESHOLD = 0.65
 
 # Timing Settings
 CLICK_DELAY = 1.0


### PR DESCRIPTION
## Summary
- Add pair-based OCR search and click helpers using Tesseract psm6
- Lower fuzzy match threshold to 0.65
- Use word pair detection for Preston readiness check and menu navigation

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py preston_rpa/preston_automation.py`
- `python -m py_compile preston_rpa/config.py`


------
https://chatgpt.com/codex/tasks/task_b_689a6e479b20832fbe1ebdcd8bb2b88d