### PR TITLE
Handle mis-encoded Turkish capital I in OCR normalization

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -73,6 +73,10 @@ class OCREngine:
 
     @staticmethod
     def _normalize(text: str) -> str:
+        try:
+            text = text.encode("latin1").decode("utf-8")
+        except UnicodeError:
+            pass
         mapping = str.maketrans({
             "İ": "I",
             "ı": "i",


### PR DESCRIPTION
## Summary
- Fix OCR normalization to decode mis-encoded Turkish characters such as 'Ä°'
- Ensures menu lookups succeed even when OCR output encoding is incorrect

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py`
- Verified `_normalize` converts `Finans - Ä°zle` to `finans - izle` via a small script


------
https://chatgpt.com/codex/tasks/task_b_689a7f24d584832fb9617f57a6ce4aa8