### PR TITLE
Improve Turkish OCR normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Bu proje, Preston muhasebe yazılımı için POS hareketlerinin otomatik olarak 
 ```bash
 pip install -r requirements.txt
 ```
-3. Windows ortamında tesseract ve gerekli ekran erişim izinleri hazır olmalıdır.
+3. Tesseract'ın Türkçe dil paketi kurulmuş olmalıdır (örn. `sudo apt-get install tesseract-ocr-tur`).
+4. Windows ortamında tesseract ve gerekli ekran erişim izinleri hazır olmalıdır.
 
 ## Kullanım
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyautogui>=0.9.54
 pygetwindow>=0.0.9
 numpy>=1.24.0
 uiautomation>=2.0.0
+pandas>=1.5.0


### PR DESCRIPTION
## Summary
- normalize OCR text with Turkish-specific demojibake handling
- detect "Finans - İzle" menu via tokenized word pairs
- document Turkish Tesseract language requirement and add pandas dependency

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py`
- `python -m py_compile preston_rpa/preston_automation.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689af945d258832fa1c7e4719534be8c