### PR TITLE
Improve OCR matching and configuration

### DIFF
--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -7,7 +7,7 @@ OCR_CONFIDENCE = 0.8
 # Use Turkish language pack
 OCR_LANGUAGE = "tur"
 # Tesseract configuration string (single line mode for menu bar)
-OCR_TESSERACT_CONFIG = "--psm 7"
+OCR_TESSERACT_CONFIG = "--oem 3 --psm 6 -c tessedit_char_whitelist=ABCÇDEFGĞHIİJKLMNOÖPQRSŞTUÜVWXYZabcçdefgğhıijklmnoöpqrsştuüvwxyz0123456789 |-"
 # Minimum similarity ratio (0-1) for fuzzy text matching in OCR
 OCR_FUZZY_THRESHOLD = 0.65
 


### PR DESCRIPTION
## Summary
- Enhance flexible_text_match with case variants and Turkish character confusion handling
- Apply unified Tesseract config with explicit whitelist for OCR
- Broaden word-pair search to cover multiple 'Finans' and 'İzle' variants in order

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py preston_rpa/config.py`


------
https://chatgpt.com/codex/tasks/task_b_689b188f4d28832fbab701574a1ac2c5