### PR TITLE
Improve OCR preprocessing and add EasyOCR fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Bu proje, Preston muhasebe yazılımı için POS hareketlerinin otomatik olarak 
 - Excel dosyalarından POSH ile başlayan ve 5+ rakamla biten açıklamaları filtreleme
 - Tarihe göre gruplama ve toplam tutar hesaplama
 - Pytesseract tabanlı OCR ile ekran üzerindeki metinleri bulma
+- EasyOCR desteği ve geliştirilmiş görüntü ön işleme ile daha yüksek doğruluk
 - OpenCV ile ikon eşleştirme
 - Streamlit ile gerçek zamanlı ilerleme ve log görüntüleme
 

--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -6,8 +6,9 @@ Configuration settings for Preston RPA system.
 OCR_CONFIDENCE = 0.8
 # Use Turkish language pack
 OCR_LANGUAGE = "tur"
-# Tesseract configuration string (single line mode for menu bar)
-OCR_TESSERACT_CONFIG = "--psm 7"
+# Tesseract base configuration; PSM (page segmentation mode) is appended at runtime
+# PSM 7 is recommended for single-line regions, while PSM 8 can be used for single words.
+OCR_TESSERACT_CONFIG = "--oem 1 -c preserve_interword_spaces=1"
 # Minimum similarity ratio (0-1) for fuzzy text matching in OCR
 OCR_FUZZY_THRESHOLD = 0.65
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pygetwindow>=0.0.9
 numpy>=1.24.0
 uiautomation>=2.0.0
 pandas>=1.5.0
+easyocr>=1.7.1


### PR DESCRIPTION
## Summary
- enhance OCR preprocessing with stronger scaling, Gaussian blur, Otsu threshold and morphology
- allow configurable PSM and region padding while preserving interword spaces
- add EasyOCR fallback and document new dependency

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py preston_rpa/config.py`
- `pip install --no-deps easyocr==1.7.1`


------
https://chatgpt.com/codex/tasks/task_b_689b1d1de5d0832f925d2e94886d9823