### PR TITLE
Improve OCR preprocessing and add EasyOCR option

### DIFF
--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -6,8 +6,12 @@ Configuration settings for Preston RPA system.
 OCR_CONFIDENCE = 0.8
 # Use Turkish language pack
 OCR_LANGUAGE = "tur"
-# Tesseract configuration string (single line mode for menu bar)
-OCR_TESSERACT_CONFIG = "--oem 3 --psm 6 -c tessedit_char_whitelist=ABCÇDEFGĞHIİJKLMNOÖPQRSŞTUÜVWXYZabcçdefgğhıijklmnoöpqrsştuüvwxyz0123456789 |-"
+# Tesseract configuration string optimized for single-line menu text
+OCR_TESSERACT_CONFIG = (
+    "--oem 1 --psm 7 "
+    "-c preserve_interword_spaces=1 "
+    "-c tessedit_char_whitelist=ABCÇDEFGĞHIİJKLMNOÖPQRSŞTUÜVWXYZabcçdefgğhıijklmnoöpqrsştuüvwxyz0123456789 |-"
+)
 # Minimum similarity ratio (0-1) for fuzzy text matching in OCR
 OCR_FUZZY_THRESHOLD = 0.65
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pygetwindow>=0.0.9
 numpy>=1.24.0
 uiautomation>=2.0.0
 pandas>=1.5.0
+easyocr>=1.7.0


### PR DESCRIPTION
## Summary
- Upscale, denoise, and threshold images with Gaussian blur, morphological operations, and Otsu for sharper OCR
- Enable optional EasyOCR engine and region padding to compare recognition approaches
- Tune Tesseract configuration for single-line text and preserve inter-word spacing

## Testing
- `python -m py_compile preston_rpa/config.py preston_rpa/ocr_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b251b24c8832fab632c134bbaef4f