### PR TITLE
Add triple OCR fallback with EasyOCR and PaddleOCR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ numpy>=1.24.0
 uiautomation>=2.0.0
 pandas>=1.5.0
 easyocr>=1.7.0
+paddlepaddle>=3.1.0
+paddleocr>=3.1.0


### PR DESCRIPTION
## Summary
- integrate EasyOCR and PaddleOCR alongside Tesseract in `OCREngine`
- implement `find_word_pair_triple_fallback` with logging to engine-specific files
- declare PaddleOCR dependencies in requirements

## Testing
- `pip install easyocr paddlepaddle paddleocr`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b2747b078832f9ef27284a405d2d8