### PR TITLE
Handle removed use_gpu arg in PaddleOCR

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -104,7 +104,13 @@ class OCREngine:
         self.debug = debug
         self.tesseract_lang = "tur"
         self.easyocr_reader = easyocr.Reader(["tr", "en"], gpu=False)
-        self.paddle_ocr = PaddleOCR(use_angle_cls=True, lang="tr", use_gpu=False)
+        try:
+            self.paddle_ocr = PaddleOCR(use_angle_cls=True, lang="tr", use_gpu=False)
+        except ValueError as err:
+            if "use_gpu" in str(err):
+                self.paddle_ocr = PaddleOCR(use_angle_cls=True, lang="tr")
+            else:
+                raise
 
         # Legacy attributes for backward compatibility
         self.use_easyocr = False


### PR DESCRIPTION
## Summary
- handle `use_gpu` argument removal in PaddleOCR to avoid ValueError

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b316f4cd8832f9519a95adb07d8a1