### PR TITLE
Clear UI logs at startup

### DIFF
--- a/preston_rpa/Preston.html
+++ b/preston_rpa/Preston.html
@@ -120,7 +120,8 @@
             setInterval(updateTime, 1000);
             setupEventListeners();
             initializeOCRTargets();
-            
+            document.getElementById('logContent').innerHTML = '';
+
             // Start in production mode - no debug logs
             console.log('Preston Xi Kurumsal Kaynak Yönetim Sistemi v2.1.4');
             console.log('Copyright © 2024 Preston Software Ltd.');

--- a/preston_rpa/logger.py
+++ b/preston_rpa/logger.py
@@ -5,11 +5,23 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 LOG_FILE = Path(__file__).resolve().parent / "automation.log"
+_log_file_cleared = False
 
 
 def get_logger(name: str = "preston_rpa") -> logging.Logger:
-    """Return a configured logger instance."""
+    """Return a configured logger instance.
+
+    The log file is cleared on first logger initialization to ensure a fresh
+    log on each application startup.
+    """
+
+    global _log_file_cleared
     logger = logging.getLogger(name)
+
+    if not _log_file_cleared and LOG_FILE.exists():
+        LOG_FILE.unlink()
+        _log_file_cleared = True
+
     if logger.handlers:
         return logger
 


### PR DESCRIPTION
## Summary
- Clear `automation.log` when the logger is first initialized to ensure fresh logs for each run
- Empty Preston UI log panel on page load

## Testing
- `python -m py_compile preston_rpa/logger.py`
- `python -m py_compile preston_rpa/*.py rpa_pos_entry.py`


------
https://chatgpt.com/codex/tasks/task_b_689b3c69c52c832f9cb7fd8ec1638123