### PR TITLE
Set precise menu region coordinates in Preston automation

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -170,7 +170,8 @@ class PrestonRPA:
                 )
                 window_rect = (0, 0, min(window.width, screen_w), min(window.height, screen_h))
             logger.info("Window rect: %s", window_rect)
-            menu_region = (0, 170, window.width, 40)  # y=170-210 arası, menü çubuğu
+            # Precise menu region coordinates from Developer Tools
+            menu_region = (300, 70, 200, 65)
             logger.info(f"Menu region: {menu_region}")
             menu_screenshot = pyautogui.screenshot(region=menu_region)
             menu_screenshot.save("debug_menu_only.png")


### PR DESCRIPTION
## Summary
- replace dynamic menu region with exact coordinates measured from developer tools for consistent navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689b5c683d14832f91a3ed6d255859cf