### PR TITLE
Adjust menu region for Finans-Izle menu

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -170,8 +170,8 @@ class PrestonRPA:
                 )
                 window_rect = (0, 0, min(window.width, screen_w), min(window.height, screen_h))
             logger.info("Window rect: %s", window_rect)
-            # Precise menu region coordinates from Developer Tools
-            menu_region = (300, 70, 200, 65)
+            # Precise menu region covering the "Finans - İzle" menu
+            menu_region = (300, 100, 500, 200)
             logger.info(f"Menu region: {menu_region}")
             menu_screenshot = pyautogui.screenshot(region=menu_region)
             menu_screenshot.save("debug_menu_only.png")


### PR DESCRIPTION
## Summary
- refine Preston menu region to fixed coordinates covering the Finans - İzle menu

## Testing
- `python -m py_compile preston_rpa/preston_automation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689b96e45170832fb348f7bcd094e6cc