### PR TITLE
Add per-engine OCR debug logging

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -178,9 +178,12 @@ class PrestonRPA:
             self.ocr._save_debug_image(menu_screenshot, "debug_menu_region")
             # Menu search screenshots
             self.ocr._screenshot(region=menu_region, step_name="menu_search_before")
-            if not self.ocr.click_word_pair(menu_region, "Finans", "İzle"):
-                if not self.ocr.click_word_pair(menu_region, "finans", "izle"):
-                    raise AssertionError("'Finans - İzle' menu not found")
+            bbox = self.ocr.find_word_pair_triple_fallback(menu_region, "Finans", "İzle")
+            if bbox:
+                x, y, w, h = bbox
+                pyautogui.click(x + w // 2, y + h // 2)
+            else:
+                raise AssertionError("'Finans - İzle' menu not found")
             self.ocr._screenshot(region=menu_region, step_name="menu_search_after")
             time.sleep(CLICK_DELAY)
             if not self.ocr.wait_for_text(UI_TEXTS["banka_hesap_izleme"], timeout=2):


### PR DESCRIPTION
## Summary
- Add debug directories for Tesseract, EasyOCR and PaddleOCR, recording recognized text and annotated screenshots.
- Introduce triple fallback method that runs all OCR engines and saves their results separately.
- Use the new fallback during menu search to diagnose missing 'Finans - İzle' text.

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py preston_rpa/preston_automation.py`


------
https://chatgpt.com/codex/tasks/task_b_689ba4fab2dc832f8951b15981865806