### PR TITLE
Fix easyocr DataFrame missing field handling

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -402,7 +402,11 @@ class OCREngine:
         for row in df.itertuples(index=False):
             if not str(row.text).strip():
                 continue
-            key = (row.page_num, row.block_num, row.par_num, row.line_num)
+            page_num = getattr(row, "page_num", 0)
+            block_num = getattr(row, "block_num", 0)
+            par_num = getattr(row, "par_num", 0)
+            line_num = getattr(row, "line_num", 0)
+            key = (page_num, block_num, par_num, line_num)
             line = lines.setdefault(
                 key,
                 {"words": [], "left": [], "top": [], "right": [], "bottom": []},


### PR DESCRIPTION
## Summary
- avoid AttributeError when easyocr DataFrame lacks page/block/par fields by using safe defaults

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c48ec4164832f8d4312b505ffad9a