### PR TITLE
Lower OCR confidence threshold

### DIFF
--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -3,7 +3,8 @@ Configuration settings for Preston RPA system.
 """
 
 # OCR Settings
-OCR_CONFIDENCE = 0.8
+# Accept slightly lower confidence OCR matches to improve robustness
+OCR_CONFIDENCE = 0.6
 # Use Turkish language pack
 OCR_LANGUAGE = "tur"
 # Tesseract configuration string optimized for single-line menu text

--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -12,7 +12,14 @@ from pathlib import Path
 import pyautogui
 import pygetwindow as gw
 
-from .config import CLICK_DELAY, FORM_FILL_DELAY, UI_TEXTS, BANK_CODES, CARI_CODES
+from .config import (
+    CLICK_DELAY,
+    FORM_FILL_DELAY,
+    UI_TEXTS,
+    BANK_CODES,
+    CARI_CODES,
+    OCR_CONFIDENCE,
+)
 from .logger import get_logger
 from .ocr_engine import OCREngine
 from .image_matcher import ImageMatcher
@@ -181,7 +188,9 @@ class PrestonRPA:
             # Menu search screenshots
             self.ocr._screenshot(region=menu_region, step_name="menu_search_before")
             bbox = self.ocr.find_text_on_screen(
-                ["İzle", "izle", "IZLE"], region=menu_region
+                ["İzle", "izle", "IZLE"],
+                region=menu_region,
+                confidence=OCR_CONFIDENCE,
             )
             if bbox:
                 x, y, w, h = bbox


### PR DESCRIPTION
## Summary
- Reduce global OCR confidence requirement to accept lower-certainty matches
- Pass configured OCR confidence to text search for more permissive menu detection

## Testing
- `python -m py_compile preston_rpa/config.py preston_rpa/preston_automation.py`
- `python - <<'PY'
from preston_rpa.preston_automation import PrestonRPA
print('loaded')
PY` *(fails: KeyError: 'DISPLAY')*


------
https://chatgpt.com/codex/tasks/task_b_689c6c421c40832fb7a623896676ba75