### PR TITLE
Refine Turkish text normalization

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 import re
+import unicodedata
 from datetime import datetime
 from typing import Optional, Tuple, Iterable
 from pathlib import Path
@@ -47,25 +48,11 @@ def normalize_tr(s: str) -> str:
     """
 
     s = demojibake(s)
-    mapping = str.maketrans(
-        {
-            "İ": "I",
-            "I": "I",
-            "ı": "i",
-            "Ş": "S",
-            "ş": "s",
-            "Ğ": "G",
-            "ğ": "g",
-            "Ç": "C",
-            "ç": "c",
-            "Ö": "O",
-            "ö": "o",
-            "Ü": "U",
-            "ü": "u",
-        }
-    )
-    s = s.translate(mapping).lower()
-    return re.sub(r"\s+", " ", s).strip()
+    s = unicodedata.normalize("NFKD", s)
+    s = s.translate(str.maketrans("İIıŞşĞğÇçÖöÜü", "IIiSsGgCcOoUu"))
+    s = re.sub(r"[-–—−-]", "-", s)
+    s = re.sub(r"\s+", " ", s).strip().lower()
+    return s
 
 
 def flexible_text_match(a: str, b: str, threshold: float = 0.8) -> bool:


### PR DESCRIPTION
## Summary
- enhance Turkish OCR normalization to handle Unicode decomposition, accented character mapping, hyphen unification, and whitespace cleanup
- import `unicodedata` to support normalization routines

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py`


------
https://chatgpt.com/codex/tasks/task_b_689c7187eb4c832fb43276b5a7e3e8e8