### PR TITLE
Ensure active window is focused

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -186,6 +186,8 @@ class PrestonRPA:
             )
             # Navigation Phase
             window = gw.getActiveWindow()
+            window.activate()
+            time.sleep(0.5)
             if not window:
                 raise AssertionError("Preston window not active")
             logger.info(


### PR DESCRIPTION
## Summary
- Activate the current window explicitly and pause briefly to maintain focus during Preston automation workflow.

## Testing
- `python3 -m py_compile preston_rpa/preston_automation.py`
- `python3 - <<'PY'
from preston_rpa.preston_automation import PrestonRPA
rpa = PrestonRPA()
try:
    rpa.execute_workflow({'tarih':'2024-01-01','islem_sayisi':1,'hesap_no':'123','toplam_tutar':100.0,'aciklama':'test'})
except Exception as e:
    print('Error running workflow:', e)
PY` *(fails: KeyError 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_b_689cb6f265c0832fa699cef80fa98605