### PR TITLE
Suppress pin_memory warnings for EasyOCR

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 import re
 import unicodedata
+import warnings
 from datetime import datetime
 from typing import Optional, Tuple, Iterable
 from pathlib import Path
@@ -19,6 +20,8 @@ import cv2
 from PIL import Image, ImageDraw
 
 import easyocr
+
+warnings.filterwarnings("ignore", message=".*pin_memory.*")
 
 from .config import (
     OCR_CONFIDENCE,


### PR DESCRIPTION
## Summary
- silence pin_memory warnings by filtering them during OCR engine import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ccc807990832fbfee308f02e9a228