### PR TITLE
Add capture_image helper for raw debug screenshots

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -118,6 +118,52 @@ class OCREngine:
         except Exception as exc:
             logger.error("Failed to save debug image: %s", exc)
 
+    def capture_image(self, region=None, step_name: str = "step", region_pad: int = 0):
+        """Capture a screenshot and save the raw image without running OCR.
+
+        Parameters
+        ----------
+        region:
+            Optional tuple ``(x, y, width, height)`` describing the region to
+            capture.  If omitted, the full screen is captured.
+        step_name:
+            Descriptive label used when saving the image to the debug run
+            directory.
+        region_pad:
+            Optional padding applied uniformly to all sides of ``region``
+            before cropping.
+
+        Returns
+        -------
+        Image | None
+            The captured PIL image or ``None`` if the capture fails.
+        """
+
+        try:
+            self.step += 1
+            step_label = f"step{self.step:02d}_{step_name}"
+
+            windows = gw.getWindowsWithTitle("Preston")
+            if windows:
+                windows[0].activate()
+                time.sleep(0.3)
+
+            img = pyautogui.screenshot()
+            if region:
+                x, y, w, h = region
+                if region_pad:
+                    x = max(0, x - region_pad)
+                    y = max(0, y - region_pad)
+                    w += region_pad * 2
+                    h += region_pad * 2
+                img = img.crop((x, y, x + w, y + h))
+
+            img.save(self.run_dir / f"{step_label}_raw.png")
+            return img
+        except Exception as exc:
+            logger.error("Capture image failed: %s", exc)
+            return None
+
     def _screenshot(self, region=None, step_name: str = "step", region_pad: int = 0):
         try:
             self.step += 1

--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -249,7 +249,7 @@ class PrestonRPA:
             menu_screenshot.save("debug_menu_only.png")
             self.ocr._save_debug_image(menu_screenshot, "debug_menu_region")
             # Menu search screenshots
-            self.ocr._screenshot(region=menu_region, step_name="menu_search_before")
+            self.ocr.capture_image(region=menu_region, step_name="menu_search_before")
             deadline = time.time() + 5
             ok = 0
             texts_out: list[str] = []
@@ -285,7 +285,7 @@ class PrestonRPA:
             else:
                 self._log_ocr_tokens("'İzle' menu not found", OCR_CONFIDENCE)
                 raise AssertionError("'İzle' menu not found")
-            self.ocr._screenshot(region=menu_region, step_name="menu_search_after")
+            self.ocr.capture_image(region=menu_region, step_name="menu_search_after")
             time.sleep(CLICK_DELAY)
             if not self.ocr.wait_for_text(
                 ["Yeni", "yeni", "YENİ"],


### PR DESCRIPTION
## Summary
- add OCREngine.capture_image to save raw screenshots without OCR processing
- use capture_image for pre/post menu debug captures in Preston automation

## Testing
- `python -m py_compile preston_rpa/ocr_engine.py preston_rpa/preston_automation.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cd8e62948832fa816515814c62b59