### PR TITLE
Refactor menu click sequence for immediate dropdown check

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -282,19 +282,20 @@ class PrestonRPA:
                 pyautogui.click(x_click, y_click)
                 logger.info("Click at %s", (x_click, y_click))
                 logger.info("Successfully clicked İzle menu")
+                if not self.ocr.wait_for_text(
+                    ["Yeni", "yeni", "YENİ"],
+                    timeout=2,
+                    region=dropdown_region,
+                    confidence=0.6,
+                ):
+                    self._log_ocr_tokens(
+                        "wait_for_text failed for 'Yeni' in İzle dropdown", 0.6
+                    )
+                    raise AssertionError("'Finans - İzle' dropdown did not open")
             else:
                 self._log_ocr_tokens("'İzle' menu not found", OCR_CONFIDENCE)
                 raise AssertionError("'İzle' menu not found")
             self.ocr.capture_image(region=menu_region, step_name="menu_search_after")
-            time.sleep(CLICK_DELAY)
-            if not self.ocr.wait_for_text(
-                ["Yeni", "yeni", "YENİ"],
-                timeout=2,
-                region=dropdown_region,
-                confidence=0.6,
-            ):
-                self._log_ocr_tokens("wait_for_text failed for 'Yeni' in İzle dropdown", 0.6)
-                raise AssertionError("'Finans - İzle' dropdown did not open")
             self.ocr._screenshot(region=window_rect, step_name="menu_after_dropdown")
             time.sleep(CLICK_DELAY)
             # Placeholder for more navigation steps...


### PR DESCRIPTION
## Summary
- Call `wait_for_text` immediately after clicking the İzle menu
- Move debug captures after dropdown check to remove blocking delays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ce3dc0338832f96dba2209a96fc74