### PR TITLE
Refine dropdown capture after İzle click

### DIFF
--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -295,8 +295,8 @@ class PrestonRPA:
             else:
                 self._log_ocr_tokens("'İzle' menu not found", OCR_CONFIDENCE)
                 raise AssertionError("'İzle' menu not found")
-            self.ocr.capture_image(region=menu_region, step_name="menu_search_after")
-            self.ocr._screenshot(region=window_rect, step_name="menu_after_dropdown")
+            self.ocr.capture_image(region=dropdown_region, step_name="menu_search_after")
+            self.ocr._screenshot(region=dropdown_region, step_name="menu_after_dropdown")
             time.sleep(CLICK_DELAY)
             # Placeholder for more navigation steps...
 


### PR DESCRIPTION
## Summary
- Limit `menu_region` usage to only locating the İzle menu item
- Capture screenshots of the dropdown area after İzle is clicked

## Testing
- `pytest -q`
- `python -m py_compile preston_rpa/preston_automation.py`


------
https://chatgpt.com/codex/tasks/task_b_689ce5d77324832fa85b7f146cc53b15