### PR TITLE
Standardize ROI handling with XYWH convention

### DIFF
--- a/preston_rpa/ocr_engine.py
+++ b/preston_rpa/ocr_engine.py
@@ -30,6 +30,7 @@ from .config import (
     OCR_FUZZY_THRESHOLD,
 )
 from .logger import get_logger
+from .utils import xywh_to_ltrb
 
 logger = get_logger(__name__)
 
@@ -160,7 +161,7 @@ class OCREngine:
                     y = max(0, y - region_pad)
                     w += region_pad * 2
                     h += region_pad * 2
-                img = img.crop((x, y, x + w, y + h))
+                img = img.crop(xywh_to_ltrb((x, y, w, h)))
 
             img.save(self.run_dir / f"{step_label}_raw.png")
             return img
@@ -187,7 +188,7 @@ class OCREngine:
                     y = max(0, y - region_pad)
                     w += region_pad * 2
                     h += region_pad * 2
-                raw_img = full_img.crop((x, y, x + w, y + h))
+                raw_img = full_img.crop(xywh_to_ltrb((x, y, w, h)))
             else:
                 raw_img = full_img
 
@@ -285,7 +286,7 @@ class OCREngine:
             overlay = full_img.copy()
             if region:
                 draw = ImageDraw.Draw(overlay)
-                draw.rectangle([x, y, x + w, y + h], outline="red", width=2)
+                draw.rectangle(xywh_to_ltrb((x, y, w, h)), outline="red", width=2)
             overlay.save(self.run_dir / f"{step_label}_search_region.png")
 
             region_used = (x, y, w, h) if region else None
@@ -614,7 +615,7 @@ class OCREngine:
         with open(log_path, "w", encoding="utf-8") as log:
             for row in df.itertuples(index=False):
                 draw.rectangle(
-                    [row.left, row.top, row.left + row.width, row.top + row.height],
+                    xywh_to_ltrb((row.left, row.top, row.width, row.height)),
                     outline="red",
                     width=1,
                 )
@@ -677,7 +678,7 @@ class OCREngine:
                 width = int(max(x_coords) - left)
                 height = int(max(y_coords) - top)
                 draw.rectangle(
-                    [left, top, left + width, top + height], outline="red", width=1
+                    xywh_to_ltrb((left, top, width, height)), outline="red", width=1
                 )
                 log.write(f"{text}\t{conf}\t{left},{top},{width},{height}\n")
                 data.append(

--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -24,6 +24,7 @@ from .config import (
 from .logger import get_logger
 from .ocr_engine import OCREngine
 from .image_matcher import ImageMatcher
+from .utils import xywh_to_ltrb
 
 logger = get_logger(__name__)
 
@@ -157,22 +158,10 @@ class PrestonRPA:
             time.sleep(0.25)
 
         try:
-            ImageGrab.grab(
-                bbox=(
-                    menu_left,
-                    menu_top,
-                    menu_left + menu_width,
-                    menu_top + menu_height,
-                )
-            ).save("debug_menu_roi.png")
-            ImageGrab.grab(
-                bbox=(
-                    center_left,
-                    center_top,
-                    center_left + center_width,
-                    center_top + center_height,
-                )
-            ).save("debug_center_roi.png")
+            ImageGrab.grab(bbox=xywh_to_ltrb(menu_roi)).save("debug_menu_roi.png")
+            ImageGrab.grab(bbox=xywh_to_ltrb(center_roi)).save(
+                "debug_center_roi.png"
+            )
         except Exception:
             pass
         self._log_ocr_tokens("Preston ready check failed; ROI screenshots saved.", OCR_CONFIDENCE)

--- a/preston_rpa/utils.py
+++ b/preston_rpa/utils.py
@@ -1,0 +1,22 @@
+"""Utility helpers for ROI (Region of Interest) management."""
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def xywh_to_ltrb(xywh: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:
+    """Convert an ``(x, y, width, height)`` box to ``(left, top, right, bottom)``.
+
+    Parameters
+    ----------
+    xywh:
+        Tuple containing ``(x, y, width, height)``.
+
+    Returns
+    -------
+    Tuple[int, int, int, int]
+        Converted ``(left, top, right, bottom)`` tuple suitable for APIs that
+        expect the LTRB format.
+    """
+    x, y, w, h = xywh
+    return x, y, x + w, y + h


### PR DESCRIPTION
## Summary
- Add `xywh_to_ltrb` utility to convert XYWH regions to left-top-right-bottom
- Use consistent XYWH ROI across automation and OCR modules, converting for APIs like `ImageGrab.grab`
- Refactor OCR engine drawing/cropping to rely on the new helper and avoid KeyErrors

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689cf1574ec4832faeef16b9a6597421