### PR TITLE
Select 'Banka hesap izleme' from İzle dropdown

### DIFF
--- a/preston_rpa/config.py
+++ b/preston_rpa/config.py
@@ -32,7 +32,7 @@ UI_TEXTS = {
         "FINANS - İZLE",
         "Finans - Izle",
     ],
-    "banka_hesap_izleme": "Banka hesap izleme",
+    "banka_hesap_izleme": ["Banka hesap izleme", "banka hesap izleme"],
     "tamam_button": "Tamam",
     "yeni_button": "Yeni",
     "kaydet_button": "Kaydet",

--- a/preston_rpa/preston_automation.py
+++ b/preston_rpa/preston_automation.py
@@ -272,15 +272,33 @@ class PrestonRPA:
                 logger.info("Click at %s", (x_click, y_click))
                 logger.info("Successfully clicked İzle menu")
                 if not self.ocr.wait_for_text(
-                    ["Yeni", "yeni", "YENİ"],
+                    UI_TEXTS["banka_hesap_izleme"],
                     timeout=2,
                     region=dropdown_region,
                     confidence=0.6,
                 ):
                     self._log_ocr_tokens(
-                        "wait_for_text failed for 'Yeni' in İzle dropdown", 0.6
+                        "wait_for_text failed for 'Banka hesap izleme' in İzle dropdown",
+                        0.6,
                     )
-                    raise AssertionError("'Finans - İzle' dropdown did not open")
+                    raise AssertionError(
+                        "'Finans - İzle' dropdown did not open or 'Banka hesap izleme' not found"
+                    )
+                bbox_dropdown = self.ocr.find_text_on_screen(
+                    UI_TEXTS["banka_hesap_izleme"],
+                    region=dropdown_region,
+                    confidence=OCR_CONFIDENCE,
+                )
+                if bbox_dropdown:
+                    dx, dy, dw, dh = bbox_dropdown
+                    pyautogui.click(dx + dw // 2, dy + dh // 2)
+                    logger.info("Clicked 'Banka hesap izleme' option")
+                else:
+                    self._log_ocr_tokens(
+                        "'Banka hesap izleme' option not found in dropdown",
+                        OCR_CONFIDENCE,
+                    )
+                    raise AssertionError("'Banka hesap izleme' option not found")
             else:
                 self._log_ocr_tokens("'İzle' menu not found", OCR_CONFIDENCE)
                 raise AssertionError("'İzle' menu not found")


### PR DESCRIPTION
## Summary
- Search for "Banka hesap izleme" instead of "Yeni" after clicking İzle menu
- Provide OCR with text variants for "Banka hesap izleme" via configuration
- Click the "Banka hesap izleme" option in the dropdown

## Testing
- `python -m py_compile preston_rpa/config.py preston_rpa/preston_automation.py`
- `pytest -q` *(no tests found)*
- `python - <<'PY'...` *(fails: KeyError: 'DISPLAY')*


------
https://chatgpt.com/codex/tasks/task_b_689d00d7d6c0832fa6f963a96b37b544