### PR TITLE
Handle UTF-8 log reading

### DIFF
--- a/preston_rpa/main.py
+++ b/preston_rpa/main.py
@@ -84,11 +84,16 @@ def main():
         if error_message is None:
             st.success("Automation finished")
 
-    log_box.text(
-        Path(__file__).with_name("automation.log").read_text()
-        if Path(__file__).with_name("automation.log").exists()
-        else ""
-    )
+    log_path = Path(__file__).with_name("automation.log")
+    if log_path.exists():
+        try:
+            log_content = log_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            st.error(f"Failed to read log file: {exc}")
+            log_content = ""
+    else:
+        log_content = ""
+    log_box.text(log_content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Ensure Streamlit log viewer reads automation.log with UTF-8
- Display log file read errors in the UI instead of crashing

## Testing
- `python -m py_compile preston_rpa/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dd7b34320832fa3ddfcf9bd9032cc